### PR TITLE
chore: deprecate warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# DEPRECATED!
+
+hexo-deployer-openshift has been deprecated.
+
 # hexo-deployer-openshift
 
 [![Build Status](https://travis-ci.org/hexojs/hexo-deployer-openshift.svg?branch=master)](https://travis-ci.org/hexojs/hexo-deployer-openshift)


### PR DESCRIPTION
Addresses https://github.com/hexojs/hexo/discussions/4847

After merge this I will do below:

* deprecate from npm
* archive this repository